### PR TITLE
fix: persist access token across sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "githunt",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "Githunt",
   "short_name": "Githunt",
   "description": "Replace the new tab with a list of Github trending repositories. Light/Dark mode.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "permissions": ["tabs", "storage", "webNavigation"],
   "host_permissions": ["https://api.github.com/*"],
   "content_security_policy": {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,7 +13,6 @@ const reposPersistConfig = {
 const settingsPersistConfig = {
   key: 'settings',
   storage,
-  blacklist: ['accessToken'],
 };
 
 export default combineReducers({


### PR DESCRIPTION
## Summary

- Remove `accessToken` from the `redux-persist` blacklist in `src/reducers/index.js` so the GitHub personal access token is persisted to localStorage across sessions.
- Previously, the token was lost on page reload: the settings modal showed an empty token field with no indication one was configured, and API calls fell back to unauthenticated (lower rate limits).

## What changed

`src/reducers/index.js`: Removed `blacklist: ['accessToken']` from the settings persist config.